### PR TITLE
Support for a Compendium Browser fork

### DIFF
--- a/compendium-folders.js
+++ b/compendium-folders.js
@@ -2754,7 +2754,7 @@ Hooks.once('setup',async function(){
     Settings.registerSettings()
     Hooks.once('ready',async function(){
         // change hook that runs to trigger compendium browser
-        if (game.modules.has('compendium-browser')){
+        if (game.modules.has('compendium-browser') || game.modules.has('compendium-browser-t20')){
             Hooks.on('renderCompendiumFolderDirectory',() => {
                 game.compendiumBrowser.hookCompendiumList();
             });


### PR DESCRIPTION
I've created a fork of Compendium Browser, but the button disappears because CF checks for the original Compendium Browser.