### PR TITLE
Fixes loading of folders for rendering compendia

### DIFF
--- a/compendium-folders.js
+++ b/compendium-folders.js
@@ -2856,7 +2856,7 @@ Hooks.once('setup',async function(){
                                     let data = {
                                         id:folderId,
                                         color:color, 
-                                        children:[entryId],
+                                        children:[entryId].concat(allFolderData[folderId]?.children || []),
                                         name:name,
                                         folderPath:folderPath,
                                         tempEntityId:entryId,


### PR DESCRIPTION
When building the folder tree before rendering a compendium folder structure, folder entries overwrite/reset their content list if they are encountered after non-folder entries. This results in items not being added to their respective folders when rendered in the compendium view.

Steps to reporduce the observed behavior:
1. Create an item folder
2. Create an item with the name "[some] item" in that folder
3. (Optional) Create an item with the name "some item" in that folder
4. Export that folder to a compendium.
5. Open the exported item compendium.
6. Observe "[some] item" being displayed outside of the folder.

The compendium db itself is being exported correctly and importing it into a game world seems to preserve the original folder structure. That said, viewing (the unlocked) compendium list allows drag&dropping those seemingly stray items into their original folders. This resulted in those items still not being rendered in the folder but instead being duplicated in the compendium db, which I guess is bad?