### PR TITLE
Load indexes instead of full compendiums

### DIFF
--- a/compendium-folders.js
+++ b/compendium-folders.js
@@ -1835,8 +1835,8 @@ async function initFolders(refresh=false){
 }
 Hooks.once('setup',async function(){
     defineClasses();
-    Settings.registerSettings()
-    game.CF.FICManager.setup()
+    Settings.registerSettings();
+    game.CF.FICManager.setup();
     Hooks.once('ready',async function(){
         // Ensure compatibility with other modules that rely on the old directory.
         Hooks.on('renderCompendiumFolderDirectory',(html,e) => {
@@ -1855,7 +1855,7 @@ Hooks.once('setup',async function(){
    
     
         Hooks.on("getCompendiumFolderDirectoryEntryContext", async (html,options) => {
-            Hooks.call("getCompendiumDirectoryEntryContext",html,options)
+            Hooks.call("getCompendiumDirectoryEntryContext",html,options);
         })
     
 });

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
     "description": "Collapsable folders for compendiums",
     "author": "Erceron",
     "version": "2.3.4",
-    "minimumCoreVersion": "0.8.2",
+    "minimumCoreVersion": "0.8.8",
     "compatibleCoreVersion":"0.8.8",
     "esmodules": [
         "./compendium-folders.js"


### PR DESCRIPTION
Uses the compendium index instead of a full document load to improve speed. Also fixes an error where it would bomb out during moveDocumentToFolder call.