### PR TITLE
feat: sidebar macros compatibility

### DIFF
--- a/fic-folders.js
+++ b/fic-folders.js
@@ -561,7 +561,12 @@ export class FICManager{
         libWrapper.register(mod, 'SceneDirectory.prototype._getFolderContextOptions', function (wrapped, ...args) {
             return wrapped(...args).concat(newContextOption);
         }, 'WRAPPER');
-        
+
+        // Compatibility with the Sidebar Macros module
+        libWrapper.register(mod, 'MacroSidebarDirectory.prototype._getFolderContextOptions', function (wrapped, ...args) {
+            return wrapped(...args).concat(newContextOption);
+        }, 'WRAPPER');
+
         // Folders In Compendium changes
         Settings.clearSearchTerms()
 


### PR DESCRIPTION
Since there is no way for me to call `FICManager.exportFolderStructureToCompendium` externally AFAIK, this PR is to add compatibility for my [Sidebar Macros](https://github.com/arcanistzed/sidebar-macros) module.