### PR TITLE
CoC7 0.9.0 works with existing compendium headers

### DIFF
--- a/fic-folders.js
+++ b/fic-folders.js
@@ -943,14 +943,7 @@ export class FICManager {
             const compendiumWindow = document.querySelector(
                 ".compendium.directory[data-pack='" + packCode + "']"
             );
-            if (
-                !e.collection.locked &&
-                game.user.isGM &&
-                !(
-                    game.system.id === "CoC7" &&
-                    game.packs.get(packCode).documentName == "Item"
-                )
-            )
+            if (!e.collection.locked && game.user.isGM)
                 FICManager.createNewFolderButtonWithinCompendium(
                     compendiumWindow,
                     packCode,
@@ -2012,12 +2005,7 @@ export class FICManager {
     }
 
     static createNewFolderButtonWithinCompendium(window, packCode) {
-        let directoryHeader = window.querySelector("header.directory-header");
-        if (
-            game.system.id === "CoC7" &&
-            window.querySelector("div.compendiumfilter") != null
-        )
-            directoryHeader = window.querySelector("div.compendiumfilter");
+        const directoryHeader = window.querySelector("header.directory-header");
         let button = document.createElement("button");
         button.classList.add("fic-create");
         button.type = "submit";


### PR DESCRIPTION
The latest release of CoC7 system https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/releases/tag/0.9.0 changes how the header is replaced in item compendiums. This is a FoundryVTT v10 release only.

Resolves Unable to create folders in Item Compendium #152