### PR TITLE
Grid, Zoom, Resize

### DIFF
--- a/compendium-folders.js
+++ b/compendium-folders.js
@@ -1371,7 +1371,7 @@ function filterSelectorBySearchTerm(parent, searchTerm, selector) {
         });
     } else {
         for (let compendium of parent.querySelectorAll(selector)) {
-            if (!compendium.innerText.toLowerCase().includes(searchTerm.toLowerCase())) {
+            if (!compendium.textContent.toLowerCase().includes(searchTerm.toLowerCase())) {
                 //Hide not matching
                 compendium.style.display = "none";
                 compendium.setAttribute("search-failed", "");

--- a/compendium-folders.js
+++ b/compendium-folders.js
@@ -1793,6 +1793,12 @@ export class Settings {
             type: String,
             default: "",
         });
+        game.settings.register(mod, "grid-settings", {
+            scope: "client",
+            config: false,
+            type: Object,
+            default: {},
+        });
         let FolderCollection = CONFIG.CompendiumFolderCollection.documentClass;
         let EntryCollection = CONFIG.CompendiumFolderCollection.documentClass;
 

--- a/fic-folders.js
+++ b/fic-folders.js
@@ -721,6 +721,10 @@ export class FICManager {
             let packCode = e.metadata.id;
             const compendiumWindow = document.querySelector(".compendium.directory[data-pack='" + packCode + "']");
             if (!e.collection.locked && game.user.isGM) FICManager.createNewFolderButtonWithinCompendium(compendiumWindow, packCode, null);
+            FICManager.addClickListeners(compendiumWindow);
+            FICManager.createZoomButtonsWithinCompendium(compendiumWindow);
+            FICManager.createResizeHandle(compendiumWindow, e);
+            FICManager.addSearchHandler(compendiumWindow, FICManager.onSearch.bind(compendiumWindow));
             if (!e.collection.index.contents.some((x) => x.name === game.CF.TEMP_ENTITY_NAME)) return;
 
             FICUtils.removeStaleOpenFolderSettings(packCode);
@@ -809,9 +813,6 @@ export class FICManager {
                     FICUtils.handleMoveToRoot(data);
                 });
             }
-
-            FICManager.createZoomButtonsWithinCompendium(compendiumWindow);
-            FICManager.createResizeHandle(compendiumWindow, e);
         });
     }
 
@@ -1893,6 +1894,29 @@ export class FICManager {
         function stopResize() {
             window.removeEventListener('mousemove', resize)
         }
+    }
+    static addClickListeners(compendiumWindow) {
+        for (let entity of compendiumWindow.querySelectorAll(".directory-item")) {
+            const thumbnail = entity.querySelector('.thumbnail');
+            if (thumbnail) {
+                thumbnail.removeEventListener('click', FICManager.openItem);
+                thumbnail.addEventListener('click', FICManager.openItem, false);
+            }
+        }
+    }
+    static openItem(ev) {
+        ev.stopPropagation();
+        ev.target.parentElement.querySelector('a').click();
+    }
+    static addSearchHandler(compendiumWindow, searchFn) {
+        const search = compendiumWindow.querySelector('input[name="search"]');
+        search.removeEventListener('keyup', searchFn);
+        search.addEventListener('keyup', searchFn);
+    }
+    static onSearch(e) {
+        const compendiumWindow = this; // bound from parent context
+        const hasValue = e.target?.value?.length > 0;
+        compendiumWindow.querySelector('.directory-list').classList.toggle('searching', hasValue);
     }
 }
 export class FICFolderAPI {

--- a/styles.css
+++ b/styles.css
@@ -341,8 +341,14 @@ button[data-key='compendium-folders.cleanupCompendiums']{
   align-items: center;
   gap: 5px;
 }
-.mode-selector .selected {
+.fic-mode-list {
   color: darkorange;
+}
+.display-mode-grid .fic-mode-grid {
+  color: darkorange;
+}
+.display-mode-grid .fic-mode-list {
+  color: inherit;
 }
 .zoom-buttons {
   display: flex;

--- a/styles.css
+++ b/styles.css
@@ -24,9 +24,6 @@ li.compendium-folder > .compendium-folder-header {
   background: rgba(255, 255, 255, 0.2);
   border-top: 1px solid #000 ;
   border-bottom: 1px solid #000 ;
-  position: sticky;
-  top: 0;
-  z-index: 9999;
 }
 li.compendium-folder > .compendium-folder-header h3 {
   margin: 0;

--- a/styles.css
+++ b/styles.css
@@ -276,3 +276,72 @@ button[data-key='compendium-folders.cleanupCompendiums']{
   background-color: #aa0000;
     color: #f0f0e0;
 }
+
+:root {
+  --compendium-image-size: var(--sidebar-item-height);
+}
+.compendium .directory-item .thumbnail {
+  width: var(--compendium-image-size);
+  height: var(--compendium-image-size);
+}
+.compendium.directory .directory-list .entry-list .directory-item.scene {
+  height: calc(var(--compendium-image-size) + 2px);
+  display: flex;
+  align-items: center;
+}
+.display-mode-grid .directory-item .document-name {
+  display: none;
+}
+.display-mode-grid .entry-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.display-mode-grid .directory-list .directory-item.scene {
+  height: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.display-mode-grid .directory-list .directory-item.scene img {
+  width: auto;
+}
+.display-mode-grid .directory-list .directory-item.scene .document-name {
+  display: block;
+}
+.header-controls {
+  flex: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 5px;
+  padding: 3px;
+}
+.mode-selector {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.mode-selector .selected {
+  color: darkorange;
+}
+.zoom-buttons {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+.compendium-resize-handle {
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  bottom: -1px;
+  right: 0;
+  background: #444;
+  padding: 2px;
+  border: 1px solid var(--color-border-dark-1);
+  border-radius: 4px 0 0 0;
+  color: var(--color-text-light-highlight);
+}
+.compendium-resize-handle i.fas {
+  transform: rotate(45deg);
+}

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,9 @@ li.compendium-folder > .compendium-folder-header {
   background: rgba(255, 255, 255, 0.2);
   border-top: 1px solid #000 ;
   border-bottom: 1px solid #000 ;
+  position: sticky;
+  top: 0;
+  z-index: 9999;
 }
 li.compendium-folder > .compendium-folder-header h3 {
   margin: 0;

--- a/styles.css
+++ b/styles.css
@@ -84,7 +84,7 @@ li.match {
   grid-template-columns: calc(36px + 2px) 1fr;
   grid-template-rows: 1fr 1fr;
   list-style: none;
-  padding: 2px 0 2px 4px;  
+  padding: 2px 0 2px 4px;
 }
 li.match > * {
   align-items: inherit;
@@ -123,7 +123,7 @@ li.compendium-folder > .compendium-folder-header .create-entity-c{
 #compendium h3 {border: 0px !important;padding: 0px !important;background: none !important;}
 /* Form styles */
 .form-compendium-list,.form-folder-list {
-  height:300px; 
+  height:300px;
   overflow:auto;
   background:rgba(0,0,0,0.05);
   border:1px solid #7a7971;
@@ -215,16 +215,16 @@ button.create-compendium{
 }
 .folder-header a.export-folder,a.import-folder,a.create-fic{
   flex: 0 0 20px;
-    text-align: center;
-    /*color: #CCC;*/
-    font-size: 14px;
+  text-align: center;
+  /*color: #CCC;*/
+  font-size: 14px;
 }
 div.compendium .compendium-folder-header > h3 > img {
   width:22px !important;
   height:22px !important;
   margin: 0 8px 0 0px !important;
   margin-bottom: -6px !important;
-  border:0px !important; 
+  border:0px !important;
   border-radius:0px !important;
 }
 /*Context menu*/
@@ -263,10 +263,10 @@ button.dialog-button.deleteAll  {
   background-color:#c51c1c
 }
 .d35ecustom #sidebar li.folder::before{
-	background:none
+  background:none
 }
 .d35ecustom #sidebar li.folder h3 i{
-	display:inline	
+  display:inline
 }
 #fix-compendium table{
   border-left: 1px solid #7a7971;
@@ -277,7 +277,7 @@ button.dialog-button.deleteAll  {
 }
 button[data-key='compendium-folders.cleanupCompendiums']{
   background-color: #aa0000;
-    color: #f0f0e0;
+  color: #f0f0e0;
 }
 
 :root {
@@ -286,6 +286,12 @@ button[data-key='compendium-folders.cleanupCompendiums']{
 .compendium .directory-item .thumbnail {
   width: var(--compendium-image-size);
   height: var(--compendium-image-size);
+}
+.compendium .directory-item {
+  cursor: pointer;
+}
+.compendium .directory-item:hover a {
+  text-shadow: 0 0 8px var(--color-shadow-primary);
 }
 .compendium.directory .directory-list .entry-list .directory-item.scene {
   height: calc(var(--compendium-image-size) + 2px);
@@ -299,6 +305,19 @@ button[data-key='compendium-folders.cleanupCompendiums']{
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
+}
+.display-mode-grid .directory-list .cfolders-container {
+  width: 100%;
+}
+.display-mode-grid .directory-list {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: wrap;
+  gap: 5px;
+  align-content: flex-start;
+}
+.display-mode-grid .directory-list .directory-item {
+  display: flex;
 }
 .display-mode-grid .directory-list .directory-item.scene {
   height: auto;


### PR DESCRIPTION
This was a bit thrown together, but it adds the ability to resize the compendium window, switch between a list and grid view of compendium items, and to zoom (scale) the item thumbnails. It also stickies the folder titles as you scroll so you can always see what folder you're in.

This is really handy when using compendiums to browse and pull in prefabs and such.

Happy to make whatever changes necessary.