### PR TITLE
Prevent obliteration of a folder by trying to move it into itself.

### DIFF
--- a/fic-folders.js
+++ b/fic-folders.js
@@ -193,6 +193,7 @@ export class FICUtils {
     static async handleMoveFolderToFolder(data, targetFolderElement) {
         const movingFolderId = data.id;
         const targetFolderId = targetFolderElement.dataset.folderId;
+        if (movingFolderId === targetFolderId) return;
 
         let movingFolder = game.customFolders.fic.folders.get(movingFolderId);
         let targetFolder = game.customFolders.fic.folders.get(targetFolderId);


### PR DESCRIPTION
I ran into issue #193 earlier tonight, so I did a little investigation and concocted this (possibly partial) solution.  This does prevent immediate destruction of the moved folder, but I'm not familiar enough with the code to say it doesn't have other consequences.