### PR TITLE
Module.json media.link to media.url

### DIFF
--- a/module.json
+++ b/module.json
@@ -56,7 +56,7 @@
     "media": [
         {
             "type": "cover",
-            "link": "https://raw.githubusercontent.com/earlSt1/vtt-compendium-folders/master/example.png"
+            "url": "https://raw.githubusercontent.com/earlSt1/vtt-compendium-folders/master/example.png"
         }
     ],
     "styles": ["./styles.css"],


### PR DESCRIPTION
The media.link term is deprecated, updated to reflect current term media.url