### PR TITLE
Fix compendium browse buttons for PF1 9.x

### DIFF
--- a/templates/compendium-directory.html
+++ b/templates/compendium-directory.html
@@ -84,25 +84,6 @@
 	</ul>
 	<!-- Directory Footer -->
 	<footer class="directory-footer">
-        {{#if isPF1}}
-            <div class="compendium-footer flexcol">
-                <div class="flexrow">
-                    <button class="compendium spells">{{localize "PF1.BrowseSpells"}}</button>
-                    <button class="compendium items">{{localize "PF1.BrowseItems"}}</button>
-                </div>
-                <div class="flexrow">
-                    <button class="compendium bestiary">{{localize "PF1.BrowseBestiary"}}</button>
-                    <button class="compendium feats">{{localize "PF1.BrowseFeats"}}</button>
-                </div>
-                <div class="flexrow">
-                    <button class="compendium classes">{{localize "PF1.BrowseClasses"}}</button>
-                    <button class="compendium races">{{localize "PF1.BrowseRaces"}}</button>
-                </div>
-		<div class="flexrow">
-                    <button class="compendium buffs">{{localize "PF1.BrowseBuffs"}}</button>
-                </div>
-            </div>
-        {{/if}}
         {{#if isD35E}}
          <div class="compendium-footer">
             <button class="compendium spells">{{localize "D35E.BrowseSpells"}}</button>


### PR DESCRIPTION
With PF1 9.0 (and still in the current 9.3), the compendium "Browse"-buttons aren't inside the sidebar template anymore. Instead, they are added by a render hook later on, apparently for v11 compatibility. See https://gitlab.com/foundryvtt_pathfinder1e/foundryvtt-pathfinder1/-/commit/c7f500a57d90f35b95b7714a3d5e22614c90e352

This means that adding the buttons in the template for this module creates duplicated buttons (see #217). Removing the extra handling here and just letting the system take care of it just plain works: the button render once and are clickable, etc.

(I don't know what this change means for the v11 version of this module, though.)